### PR TITLE
fescar-samples-springboot module start error #42

### DIFF
--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -163,10 +163,6 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>
-				<exclusion>
-					<artifactId>dubbo</artifactId>
-					<groupId>com.alibaba</groupId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/springboot/src/main/resources/application.yml
+++ b/springboot/src/main/resources/application.yml
@@ -12,9 +12,9 @@ spring:
         force: true
     datasource:
         driverClassName: com.mysql.jdbc.Driver
-        url: jdbc:mysql://123.123.123:3060/your_schema?useSSL=false
-        username: your_username
-        password: yout_password
+        url: jdbc:mysql://localhost:3306/fescar?useSSL=false&serverTimezone=UTC
+        username: root
+        password: root
         poolPingConnectionsNotUsedFor: 60000
         removeAbandoned: true
         connectionProperties: druid.stat.mergeSql=true;druid.stat.slowSqlMillis=5000

--- a/springboot/src/main/resources/sql/initial_db.sql
+++ b/springboot/src/main/resources/sql/initial_db.sql
@@ -31,7 +31,7 @@ CREATE TABLE `t_asset`  (
   `amount` decimal(12, 0) NOT NULL COMMENT '',
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE = InnoDB;
-
+INSERT INTO `t_asset` VALUES ('DF001', 'e2d1c4512d554db9ae4a5f30cbc2e4b1', '1');
 -- ----------------------------
 -- Table structure for undo_log
 -- ----------------------------


### PR DESCRIPTION
1.start throw exception:
Caused by: java.lang.ClassNotFoundException: com.alibaba.dubbo.qos.server.DubboLogo
2.initial_db.sql:
no t_asset table init record,for the code ,it need init